### PR TITLE
Allow to more easily override the library locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 if(MSVC)
-    # Append msvcContribDir to CMAKE_PREFIX_PATH
-    # Set CMAKE_LIBRARY_ARCHITECTURE and CONTRIB_DLL_DIR
+    # Append msvcContribDir to CMAKE_SYSTEM_PREFIX_PATH and set default for CMAKE_LIBRARY_ARCHITECTURE
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         set(CMAKE_LIBRARY_ARCHITECTURE "x86" CACHE INTERNAL "")
     else()
@@ -18,10 +17,10 @@ if(MSVC)
         include(GatherDll)
         gather_dll_add(${CONTRIB_DLLS})
     endif()
-    list(APPEND CMAKE_PREFIX_PATH ${msvcContribDir})
-    list(APPEND CMAKE_PROGRAM_PATH ${msvcContribDir}/buildTools ${_dllDir})
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
-    set(CMAKE_PROGRAM_PATH ${CMAKE_PROGRAM_PATH} PARENT_SCOPE)
+    list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${msvcContribDir})
+    list(APPEND CMAKE_SYSTEM_PROGRAM_PATH ${msvcContribDir}/buildTools ${_dllDir})
+    set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH} PARENT_SCOPE)
+    set(CMAKE_SYSTEM_PROGRAM_PATH ${CMAKE_SYSTEM_PROGRAM_PATH} PARENT_SCOPE)
 ENDIF()
 
 ################################################################################
@@ -30,8 +29,8 @@ ENDIF()
 
 # Here we set hints to lua libraries used for official builds.
 # Normally those should be on the build server but we make them available here for convenience.
-# As this will be appended to CMAKE_PREFIX_PATH one can use other versions by setting
-# that appropriately
+# As this will be appended to CMAKE_SYSTEM_PREFIX_PATH one can use other versions by setting
+# CMAKE_PREFIX_PATH or CMAKE_SYSTEM_PREFIX_PATH appropriately
 
 set(_contrib_lua_path ${CMAKE_CURRENT_LIST_DIR}/lua)
 set(_contrib_lua_libpath "")
@@ -39,8 +38,8 @@ set(_contrib_lua_libpath "")
 if(MSVC)
     # Library is in contrib archive which is in prefix path.
     # We just need the includes (which we did not duplicate in the msvc-contrib)
-    list(APPEND CMAKE_PREFIX_PATH ${_contrib_lua_path})
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
+    list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${_contrib_lua_path})
+    set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH} PARENT_SCOPE)
 elseif(WIN32 OR CYGWIN)
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(_contrib_lua_libpath ${_contrib_lua_path}/win64)
@@ -65,7 +64,7 @@ if(_contrib_lua_libpath)
         list(APPEND CMAKE_FIND_ROOT_PATH ${_contrib_lua_path} ${_contrib_lua_libpath})
         set(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH} PARENT_SCOPE)
     else()
-        list(APPEND CMAKE_PREFIX_PATH ${_contrib_lua_path} ${_contrib_lua_libpath})
-        set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
+        list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${_contrib_lua_path} ${_contrib_lua_libpath})
+        set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH} PARENT_SCOPE)
     endif()
 endif()


### PR DESCRIPTION
Set CMAKE_SYSTEM_* instead of e.g. CMAKE_PREFIX_PATH as those will be searched later.
Appending will search ours AFTER the users location(s).